### PR TITLE
Module name collisions fix

### DIFF
--- a/gradle-plugin/src/main/java/org/lsposed/lsparanoid/plugin/LSParanoidPlugin.kt
+++ b/gradle-plugin/src/main/java/org/lsposed/lsparanoid/plugin/LSParanoidPlugin.kt
@@ -46,7 +46,7 @@ class LSParanoidPlugin : Plugin<Project> {
                     it.classpath = variant.compileClasspath
                     it.seed.set(extension.seed ?: SecureRandom().nextInt())
                     it.classFilter = extension.classFilter
-                    it.projectName.set("${project.rootProject.name}\$${project.name}")
+                    it.projectName.set("${project.rootProject.name}\$${project.path}")
                 }
                 variant.artifacts.forScope(if (extension.includeDependencies) Scope.ALL else Scope.PROJECT).use(task)
                     .toTransform(


### PR DESCRIPTION
There is a problem using the plugin in a multi module project. If you apply the plugin to modules with the same name, it will fail. For example if you have:

```
:moduleA:data
:moduleB:data
```

And you apply the plugin in both, it will fail.
Using project.path instead of project.name will fix this